### PR TITLE
1.0.1 Buxfixes for isTheFeatureAlreadyLoaded

### DIFF
--- a/_featureLoader/featureLoader.json
+++ b/_featureLoader/featureLoader.json
@@ -183,7 +183,7 @@
   "website"     : "https:/developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent"
  },
 
-  "getQueryStringAsObj": {
+ "getQueryStringAsObj": {
   "type"        : "customFunction",
   "text"        : "Breaks out the queryString into key/value pairs and returns them as an object.",
   "req"         : false,

--- a/_featureLoader/js/featureLoader.js
+++ b/_featureLoader/js/featureLoader.js
@@ -13,6 +13,7 @@ var featureDetection = {
 		includeWebsite : false ,
 		userReqs  : []
 	},
+	version: "vd1 1.0.1",
 	funcs:{
 		// Performs eval within the specified context on a string.
 		evalInContext             : function(js, context) {
@@ -21,34 +22,41 @@ var featureDetection = {
 		} ,
 		// Checks if the feature has already been loaded.
 		isTheFeatureAlreadyLoaded : function(feature){
+			// NOTE: Returning a true means that the feature already exists or it is an unknown feature.
+			// NOTE: Returning a true means do not try to load the specified feature.
+
 			var keys = Object.keys(featureDetection.reqs);
 
 			// Check right away if the feature's test will pass.
 			try{
 				// Does the test pass?
 				if( eval(featureDetection.reqs[feature].test) === false ){
-					// This feature CAN be loaded.
+					// This feature does not exist and CAN be loaded.
 					return false;
 				}
 				else                                                    {
-					throw "The specified feature is missing.";
+					// This feature already exists.
+					return true;
 				}
 			}
 			catch(e){
 				// Is the requested feature one that is known to us?
 				if     ( keys.indexOf(feature) == -1 ){
-					console.log("  -- UNKNOWN FEATURE:", feature, "(E:1)");
+					console.warn("  -- UNKNOWN FEATURE:", feature, "(E:1)");
+					// Unknown feature. Don't try to load it.
 					return true;
 				}
 
 				// Similar check to the one above (likely redunant.)
 				else if( featureDetection.reqs[feature] == undefined ){
-					console.log("  -- UNKNOWN FEATURE:", feature, "(E:2)");
+					console.warn("  -- UNKNOWN FEATURE:", feature, "(E:2)");
+					// Unknown feature. Don't try to load it.
 					return true;
 				}
 
 				// This feature CAN be loaded.
 				else{
+					// This feature does not exist and CAN be loaded.
 					return false;
 				}
 			}

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta charset="UTF-8">
 	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
-	<title>Feature Loader v1c</title>
+	<title>Feature Loader v1d 1.0.1</title>
 
 	<!-- CSS -->
 	<link rel="stylesheet" type="text/css" href="css/css_reset.css">
@@ -26,7 +26,7 @@
 <body>
 	<div id="header">
 		<hr>
-		Feature Loader v1c
+		Feature Loader v1d 1.0.1
 		<hr>
 	</div>
 

--- a/js/index.js
+++ b/js/index.js
@@ -162,9 +162,9 @@ function addLinksToHomepage(){
 
 window.onload = function(){
 	window.onload = null;
-	console.log("********************************");
-	console.log("*** -- Feature Loader v1c -- ***");
-	console.log("********************************");
+	console.log("**************************************");
+	console.log("*** -- Feature Loader v1d 1.0.1 -- ***");
+	console.log("**************************************");
 
 	// Feature Loader config:
 	featureDetection.config.usePhp         = false;


### PR DESCRIPTION
- Changed demo output to reflect the new version.
- Changed the console output for unknown features to use console.warn.
-- This will provide the ability to trace where the call was made in the application trying to add the feature.
- Bugfix to function isTheFeatureAlreadyLoaded. If a feature was already loaded it would throw an error.
-- This was incorrect behavior. Now it returns true, meaning "do not load this feature."
- The version value is now stored in featureDetection.version as a string.